### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @Sage-Bionetworks/dpe


### PR DESCRIPTION
This allows the DPE team to be tagged as a reviewer automatically.